### PR TITLE
Update Opox

### DIFF
--- a/Opox
+++ b/Opox
@@ -1,1 +1,53 @@
-
+port: 7890
+socks-port: 7891
+redir-port: 7892
+mixed-port: 7893
+tproxy-port: 7895
+ipv6: false
+mode: rule
+log-level: silent
+allow-lan: true
+external-controller: 0.0.0.0:9090
+secret: ""
+bind-address: "*"
+unified-delay: true
+profile:
+  store-selected: true
+dns:
+  enable: true
+  ipv6: false
+  enhanced-mode: redir-host
+  listen: 127.0.0.1:7874
+  nameserver:
+    - 1.1.1.1
+    - 1.0.0.1
+  fallback:
+    - https://cloudflare-dns.com/dns-query
+    - https://dns.google/dns-query
+  default-nameserver:
+    - 8.8.8.8
+    - 8.8.4.4
+proxies:
+  - name: sshocean-indosiasat
+    server: id4.v2vless.site
+    port: 443
+    type: vless
+    uuid: 3af42e67-b628-4c89-896f-c3fd9fe56ddb
+    cipher: auto
+    tls: true
+    skip-cert-verify: true
+    servername: space.byu.id
+    network: ws
+    ws-opts:
+      path: /vless
+      headers:
+        Host: id4.v2vless.site
+    udp: true
+proxy-groups:
+  - name: SSHOCEAN
+    type: select
+    proxies:
+      - sshocean-indosiasat
+      - DIRECT
+rules:
+  - MATCH,SSHOCEAN


### PR DESCRIPTION
port: 7890
socks-port: 7891
redir-port: 7892
mixed-port: 7893
tproxy-port: 7895
ipv6: false
mode: rule
log-level: silent
allow-lan: true
external-controller: 0.0.0.0:9090
secret: ""
bind-address: "*"
unified-delay: true
profile:
  store-selected: true
dns:
  enable: true
  ipv6: false
  enhanced-mode: redir-host
  listen: 127.0.0.1:7874
  nameserver:
    - 1.1.1.1
    - 1.0.0.1
  fallback:
    - https://cloudflare-dns.com/dns-query
    - https://dns.google/dns-query
  default-nameserver:
    - 8.8.8.8
    - 8.8.4.4
proxies:
  - name: sshocean-indosiasat
    server: id4.v2vless.site
    port: 443
    type: vless
    uuid: 3af42e67-b628-4c89-896f-c3fd9fe56ddb
    cipher: auto
    tls: true
    skip-cert-verify: true
    servername: space.byu.id
    network: ws
    ws-opts:
      path: /vless
      headers:
        Host: id4.v2vless.site
    udp: true
proxy-groups:
  - name: SSHOCEAN
    type: select
    proxies:
      - sshocean-indosiasat
      - DIRECT
rules:
  - MATCH,SSHOCEAN